### PR TITLE
Enhance evaluation harness gap reporting

### DIFF
--- a/ops/evaluation_harness/README.md
+++ b/ops/evaluation_harness/README.md
@@ -12,6 +12,37 @@ python ops/evaluation_harness/evaluate.py \
 
 The script reports JD coverage, ATS keyword coverage, hallucination flags, bullet consistency, and reading-grade level. Integrate the JSON output into CodeBuild or Step Functions to gate production releases.
 
+### Output Report Fields
+
+Each run prints a single JSON object with the following fields:
+
+| Field | Description | Remediation Guidance |
+| ----- | ----------- | -------------------- |
+| `jdCoverage` | Ratio of JD targets (requirements, responsibilities, skills, competency cues) that appear in the tailored resume. | Rewrite bullets or summary lines so that every high-priority JD statement is reflected. |
+| `missingCoverageTargets` | Ordered list of JD targets that were not detected in the resume text after stemming/token normalization. | Provide explicit achievements or phrasing that mention these targets. |
+| `atsKeywordScore` | Fraction of ATS keywords satisfied. Keywords include JD skills, explicit keyword lists, and competency evidence indicators. | Add missing keywords to the skills block or weave them into experience bullets. |
+| `missingAtsKeywords` | Keywords absent from the resume tokens. | Add to the resume skills list or weave into relevant bullets. |
+| `hallucinations` | Bullets that lack supporting evidence from the JD or retrieval context. | Replace the bullet with factual content or enrich the retrieval set. |
+| `consistency` | Measures variance in bullet lengths (1.0 is perfectly consistent). | Trim overly long bullets and expand short ones for balance. |
+| `readabilityGradeLevel` | Flesch–Kincaid reading grade level for the summary and experience sections. | Target grade ≤10 for broad readability unless the tenant requires technical depth. |
+
+```json
+{
+  "jdCoverage": 0.75,
+  "missingCoverageTargets": [
+    "Build data governance dashboards",
+    "Define stakeholder communication cadences"
+  ],
+  "atsKeywordScore": 0.6,
+  "missingAtsKeywords": ["Snowflake", "Airflow"],
+  "hallucinations": [],
+  "consistency": 0.83,
+  "readabilityGradeLevel": 9.4
+}
+```
+
+> **Tip:** Feed the `missingCoverageTargets` and `missingAtsKeywords` arrays back into a secondary prompt (“gap fill” stage) to automatically iterate on weak drafts.
+
 ## Human-in-the-loop Review Screen
 Host a lightweight review UI using Amazon S3 static website hosting or AWS Amplify:
 

--- a/ops/evaluation_harness/evaluate.py
+++ b/ops/evaluation_harness/evaluate.py
@@ -1,18 +1,31 @@
-"""Evaluation harness for tailored resumes."""
+"""Evaluation harness for tailored resumes.
+
+The script inspects pipeline outputs (parsed job description, tailored resume,
+and optional retrieval context) and reports a quality summary.  Originally the
+tool surfaced only aggregate scores, which made it difficult for reviewers to
+pinpoint concrete gaps in the tailored content.  The evaluator now enumerates
+missing coverage items and ATS keywords directly in the report so that
+operators can act on the findings without re-running analysis by hand.
+"""
 from __future__ import annotations
 
 import argparse
 import json
 import math
+import string
 import sys
 from dataclasses import dataclass
-from typing import Dict, List, Set
+from typing import Dict, Iterable, List, Sequence, Set, Tuple
 
 
 @dataclass
 class EvaluationResult:
+    """Structured representation of evaluation metrics."""
+
     jd_coverage: float
+    missing_jd_targets: List[str]
     ats_keyword_score: float
+    missing_keywords: List[str]
     hallucination_flags: List[str]
     consistency_score: float
     readability_grade: float
@@ -20,7 +33,9 @@ class EvaluationResult:
     def to_dict(self) -> Dict:
         return {
             "jdCoverage": self.jd_coverage,
+            "missingCoverageTargets": self.missing_jd_targets,
             "atsKeywordScore": self.ats_keyword_score,
+            "missingAtsKeywords": self.missing_keywords,
             "hallucinations": self.hallucination_flags,
             "consistency": self.consistency_score,
             "readabilityGradeLevel": self.readability_grade,
@@ -44,34 +59,71 @@ def main(argv: List[str]) -> int:
 
 
 def evaluate(job: Dict, resume: Dict, retrieval: Dict) -> EvaluationResult:
-    jd_coverage = _coverage_score(job, resume)
-    ats_keyword_score = _ats_keyword_score(job, resume)
+    jd_coverage, missing_targets = _coverage_score(job, resume)
+    ats_keyword_score, missing_keywords = _ats_keyword_score(job, resume)
     hallucinations = _hallucination_flags(job, resume, retrieval)
     consistency = _consistency_score(resume)
     readability = _readability_grade(resume)
-    return EvaluationResult(jd_coverage, ats_keyword_score, hallucinations, consistency, readability)
+    return EvaluationResult(
+        jd_coverage,
+        missing_targets,
+        ats_keyword_score,
+        missing_keywords,
+        hallucinations,
+        consistency,
+        readability,
+    )
 
 
-def _coverage_score(job: Dict, resume: Dict) -> float:
-    targets: List[str] = job.get("requirements", []) + job.get("responsibilities", []) + job.get("skills", [])
+def _coverage_score(job: Dict, resume: Dict) -> Tuple[float, List[str]]:
+    """Calculate JD coverage and list uncovered targets.
+
+    Coverage is derived from requirements, responsibilities, skills, and
+    competency cues surfaced in the parsed JD.  A target is considered covered
+    when all significant tokens appear in the resume text (after light
+    stemming).  Returning the missing targets provides direct guidance on which
+    statements the generation step should reinforce.
+    """
+
+    targets = list(_iter_jd_targets(job))
     if not targets:
-        return 1.0
-    total = len(targets)
+        return 1.0, []
+
+    resume_tokens = _collect_resume_tokens(resume)
+    missing: List[str] = []
     hits = 0
-    resume_text = json.dumps(resume).lower()
-    for item in targets:
-        if item and item.lower() in resume_text:
+
+    for target in targets:
+        tokenized = _tokenize(target)
+        if tokenized and tokenized.issubset(resume_tokens):
             hits += 1
-    return round(hits / total, 3)
+        else:
+            missing.append(target)
+
+    score = round(hits / len(targets), 3)
+    return score, missing
 
 
-def _ats_keyword_score(job: Dict, resume: Dict) -> float:
-    keywords = set([skill.lower() for skill in job.get("skills", [])])
-    resume_skills = set([skill.lower() for skill in resume.get("skills", [])])
+def _ats_keyword_score(job: Dict, resume: Dict) -> Tuple[float, List[str]]:
+    """Score ATS keyword coverage and return missing keywords."""
+
+    keywords = _collect_keywords(job)
     if not keywords:
-        return 1.0
-    matches = keywords.intersection(resume_skills)
-    return round(len(matches) / len(keywords), 3)
+        return 1.0, []
+
+    resume_tokens = _collect_resume_tokens(resume) | _tokenize_iter(resume.get("skills", []))
+    missing: List[str] = []
+    hits = 0
+
+    for keyword in keywords:
+        tokens = _tokenize(keyword)
+        if tokens and tokens.issubset(resume_tokens):
+            hits += 1
+        else:
+            missing.append(keyword)
+
+    score = round(hits / len(keywords), 3)
+    return score, missing
 
 
 def _hallucination_flags(job: Dict, resume: Dict, retrieval: Dict) -> List[str]:
@@ -140,6 +192,72 @@ def _iter_bullets(resume: Dict) -> List[str]:
 def _load_json(path: str) -> Dict:
     with open(path, "r", encoding="utf-8") as handle:
         return json.load(handle)
+
+
+def _iter_jd_targets(job: Dict) -> Iterable[str]:
+    yield from job.get("requirements", [])
+    yield from job.get("responsibilities", [])
+    yield from job.get("skills", [])
+    for competency in job.get("competencies", []) or []:
+        name = competency.get("name")
+        if name:
+            yield name
+        for indicator in competency.get("evidenceIndicators", []) or []:
+            if indicator:
+                yield indicator
+
+
+def _collect_resume_tokens(resume: Dict) -> Set[str]:
+    """Tokenize all salient resume text for coverage matching."""
+
+    segments: List[str] = [resume.get("summary", "")]
+    segments.extend(_iter_bullets(resume))
+    segments.extend(resume.get("skills", []))
+    for project in resume.get("projects", []) or []:
+        segments.append(project.get("name", ""))
+        segments.append(project.get("description", ""))
+    return _tokenize_iter(segments)
+
+
+def _tokenize_iter(values: Sequence[str]) -> Set[str]:
+    tokens: Set[str] = set()
+    for value in values or []:
+        tokens |= _tokenize(value)
+    return tokens
+
+
+def _tokenize(value: str) -> Set[str]:
+    cleaned = value.lower() if isinstance(value, str) else ""
+    if not cleaned:
+        return set()
+    stripped = cleaned.translate(str.maketrans({ch: " " for ch in string.punctuation}))
+    tokens = {_normalize_token(token) for token in stripped.split() if token}
+    return {token for token in tokens if token}
+
+
+def _normalize_token(token: str) -> str:
+    token = token.strip()
+    if not token:
+        return ""
+
+    if token.endswith("ing") and len(token) > 4:
+        token = token[:-3]
+    elif token.endswith("ed") and len(token) > 3:
+        token = token[:-2]
+    elif token.endswith("es") and len(token) > 4:
+        token = token[:-2]
+    elif token.endswith("s") and len(token) > 3:
+        token = token[:-1]
+    return token
+
+
+def _collect_keywords(job: Dict) -> List[str]:
+    keywords: List[str] = []
+    keywords.extend(job.get("skills", []))
+    keywords.extend(job.get("keywords", []))
+    for competency in job.get("competencies", []) or []:
+        keywords.extend(competency.get("evidenceIndicators", []) or [])
+    return [kw for kw in keywords if isinstance(kw, str) and kw.strip()]
 
 
 if __name__ == "__main__":

--- a/tests/test_evaluation_harness.py
+++ b/tests/test_evaluation_harness.py
@@ -1,0 +1,51 @@
+"""Tests for the evaluation harness quality report."""
+
+from ops.evaluation_harness.evaluate import EvaluationResult, evaluate
+
+
+def test_evaluate_surfaces_missing_targets_and_keywords() -> None:
+    job = {
+        "requirements": ["Design ML systems", "Write Python code"],
+        "responsibilities": ["Collaborate with stakeholders"],
+        "skills": ["Python", "AWS"],
+        "competencies": [
+            {
+                "name": "Leadership",
+                "priority": 3,
+                "evidenceIndicators": ["cross functional alignment"],
+            }
+        ],
+    }
+    resume = {
+        "summary": "Demonstrated leadership in cross functional alignment for ML programs.",
+        "experience": [
+            {
+                "title": "ML Engineer",
+                "company": "Example",
+                "startDate": "2020-01-01",
+                "endDate": "2022-12-31",
+                "achievements": [
+                    "Designing ML systems for patient analytics.",
+                    "Led cross functional alignment across product and data teams.",
+                    "Automated data pipelines with Python and SQL.",
+                ],
+            }
+        ],
+        "skills": ["Python", "SQL"],
+    }
+    retrieval = {"chunks": [{"text": "Cross functional alignment notes from stakeholders."}]}
+
+    result = evaluate(job, resume, retrieval)
+
+    assert isinstance(result, EvaluationResult)
+    assert result.jd_coverage == 0.571
+    assert result.ats_keyword_score == 0.667
+    assert "Write Python code" in result.missing_jd_targets
+    assert "Collaborate with stakeholders" in result.missing_jd_targets
+    assert "AWS" in result.missing_keywords
+
+    report = result.to_dict()
+    assert "missingCoverageTargets" in report
+    assert "missingAtsKeywords" in report
+    assert report["missingCoverageTargets"] == result.missing_jd_targets
+    assert report["missingAtsKeywords"] == result.missing_keywords


### PR DESCRIPTION
## Summary
- surface missing JD targets and ATS keywords in the evaluation harness output for actionable guidance
- expand tokenization logic to include competencies and light stemming for coverage checks
- document the JSON report fields and add unit tests around the evaluator behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f9c5f61ff0832389081c557d20376a